### PR TITLE
Follow up fix to avoid confusion when infest rotation gets interrupted by phase transition

### DIFF
--- a/DBM-Icecrown/TheFrozenThrone/LichKing.lua
+++ b/DBM-Icecrown/TheFrozenThrone/LichKing.lua
@@ -120,7 +120,10 @@ local function jaGetNextPaladinForRaidCD()
 	if not INFEST_ROTA or #INFEST_ROTA == 0 then return "Unknown" end
 
 	local currentPaladin = INFEST_ROTA[jaLastPaladin]
-	jaLastPaladin = _G["mod"](jaLastPaladin, #INFEST_ROTA) + 1
+	jaLastPaladin = jaLastPaladin + 1
+    if jaLastPaladin > #INFEST_ROTA then
+        jaLastPaladin = 1
+    end
 	return currentPaladin
 end
 
@@ -382,6 +385,10 @@ function mod:SPELL_CAST_START(args)
 		countdownDefile:Cancel()
 		warnDefileSoon:Cancel()
 
+        jaLastPaladin = jaLastPaladin - 1
+        if jaLastPaladin < 1 then
+            jaLastPaladin = #INFEST_ROTA
+        end
 		jaTimerRaidCooldown:Cancel()
 		jaSpecialWarningCD:Cancel()
 	elseif args:IsSpellID(72262) then -- Quake (phase transition end)


### PR DESCRIPTION
The problem people had in our guild was that they got called out to do the next raid CD right before an intermission phase started, and then the timer got aborted cause of the P1->P2 intermission, and afterwards the rotation called out a new player. That lead to confusion.

This fix makes sure that the same player is called out before and after the intermission